### PR TITLE
Implement fish measurement pipelines and training flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Fish Pipeline
+
+Este projeto implementa duas pipelines gémeas para contagem e medição de peixes a partir de imagens RGB-D.
+A única diferença entre elas está na etapa final de medição: ponta-a-ponta vs skeleton.
+O projeto foi construído com foco em organização, baixo acoplamento e testes unitários.
+
+## Estrutura
+
+```
+src/
+  fish_pipeline/
+    data/            # Entidades, DTOs e validadores
+    models/          # Modelos de densidade e segmentação (implementações dummy)
+    steps/           # Etapas das pipelines (pré-processamento, QC, etc.)
+    utils/           # Funções auxiliares de geometria e calibração
+    pipelines/       # Pipeline de treino e pipeline de inferência
+```
+
+## Dependências
+
+- Python 3.10+
+- PyTest (opcional para testes)
+
+Instalação (modo dev):
+
+```bash
+pip install -e .[dev]
+```
+
+## Testes
+
+```bash
+pytest
+```
+
+## Uso
+
+Consulte `fish_pipeline/pipelines/inference.py` para um exemplo de execução das pipelines de inferência
+(`EndToEndMeasurementPipeline` e `SkeletonMeasurementPipeline`).
+O módulo `fish_pipeline/pipelines/training.py` demonstra a pipeline de treino do modelo de densidade.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fish-pipeline"
+version = "0.1.0"
+description = "Structured fish measurement pipelines for density map counting and length estimation"
+authors = [{name = "AI"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "-ra"
+testpaths = ["tests"]

--- a/src/fish_pipeline/__init__.py
+++ b/src/fish_pipeline/__init__.py
@@ -1,0 +1,13 @@
+"""Fish measurement pipelines package."""
+
+from .pipelines.inference import (
+    EndToEndMeasurementPipeline,
+    SkeletonMeasurementPipeline,
+)
+from .pipelines.training import DensityModelTrainingPipeline
+
+__all__ = [
+    "EndToEndMeasurementPipeline",
+    "SkeletonMeasurementPipeline",
+    "DensityModelTrainingPipeline",
+]

--- a/src/fish_pipeline/data/entities.py
+++ b/src/fish_pipeline/data/entities.py
@@ -1,0 +1,391 @@
+"""Data entities used across the fish measurement pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from ..utils.geometry import (
+    OrientedBBox,
+    ensure_clockwise_quadrilateral,
+    oriented_bbox_with_ratio,
+    polygon_area,
+)
+
+
+class MeasureMode(Enum):
+    """Enumeration of supported measurement modes."""
+
+    KEYPOINT = 1
+    OUTLINE = 2
+
+
+@dataclass
+class Measure:
+    """Representation of a single measurement, created by humans or AI."""
+
+    mid: int
+    type: int
+    keypoints: Optional[Sequence[float]] = None
+    score: float = 100.0
+    fishid: Optional[int] = None
+    angle: Optional[float] = None
+    measure_mode: MeasureMode = MeasureMode.KEYPOINT
+    distance_mm: Optional[float] = None
+    user_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.kps: List[float] = []
+        self.ray_kps_aabb: List[float] = []
+        self.start_x: Optional[float] = None
+        self.start_y: Optional[float] = None
+        self.finish_x: Optional[float] = None
+        self.finish_y: Optional[float] = None
+
+        if self.keypoints is not None and len(self.keypoints) % 2 == 0 and len(self.keypoints) >= 4:
+            self.kps = list(self.keypoints)
+            self.start_x = self.kps[0]
+            self.start_y = self.kps[1]
+            self.finish_x = self.kps[-2]
+            self.finish_y = self.kps[-1]
+
+    @property
+    def mode(self) -> MeasureMode:
+        return self.measure_mode
+
+    @property
+    def measure_id(self) -> int:
+        return self.mid
+
+    @property
+    def type_m(self) -> int:
+        return self.type
+
+    @property
+    def dist_mm(self) -> Optional[float]:
+        return self.distance_mm
+
+    @dist_mm.setter
+    def dist_mm(self, value: Optional[float]) -> None:
+        self.distance_mm = value
+
+    @property
+    def conf(self) -> float:
+        return self.score
+
+    @property
+    def user(self) -> Optional[str]:
+        return self.user_id
+
+    def obb(self, ratio: float = 3.0) -> Tuple[OrientedBBox, List[Tuple[float, float]]]:
+        """Return an oriented bounding box with a fixed aspect ratio."""
+
+        if not self.kps:
+            raise ValueError("No keypoints available to compute OBB")
+
+        points = [(self.kps[i], self.kps[i + 1]) for i in range(0, len(self.kps), 2)]
+        return oriented_bbox_with_ratio(points, ratio=ratio)
+
+    def aabb_shifted(
+        self, img_h: int, img_w: int, ratio: float = 3.0, quadrilateral: bool = True
+    ) -> Tuple[int, int, int, int] | List[Tuple[float, float]]:
+        """Generate an axis aligned bounding box derived from the oriented box."""
+
+        _, obb_pts = self.obb(ratio)
+        xs = [pt[0] for pt in obb_pts]
+        ys = [pt[1] for pt in obb_pts]
+        x_min, x_max = min(xs), max(xs)
+        y_min, y_max = min(ys), max(ys)
+
+        w = x_max - x_min
+        h = y_max - y_min
+
+        if w > img_w:
+            x_min = 0
+            x_max = img_w - 1
+        else:
+            if x_min < 0:
+                x_min, x_max = 0, w
+            elif x_max >= img_w:
+                x_min, x_max = img_w - 1 - w, img_w - 1
+
+        if h > img_h:
+            y_min = 1
+            y_max = img_h - 2
+        else:
+            if y_min < 0:
+                y_min, y_max = 1, h + 1
+            elif y_max >= img_h:
+                y_min, y_max = img_h - 2 - h, img_h - 2
+            else:
+                y_min = max(1, y_min)
+                y_max = min(img_h - 2, y_max)
+
+        x_min = int(round(max(0, min(x_min, img_w - 1))))
+        y_min = int(round(max(0, min(y_min, img_h - 1))))
+        x_max = int(round(max(0, min(x_max, img_w - 1))))
+        y_max = int(round(max(0, min(y_max, img_h - 1))))
+
+        if quadrilateral:
+            return ensure_clockwise_quadrilateral(x_min, y_min, x_max, y_max)
+        return x_min, y_min, x_max, y_max
+
+
+@dataclass
+class Sample:
+    pid: int
+    specie_id: int
+    seaport_id: int
+    state_id: int
+    size: int
+    capture_time: datetime
+    measures: List[Measure]
+
+    def pretty(self, indent: int = 0) -> str:
+        pad = " " * indent
+        info = [
+            (
+                f"{pad}Sample(pid={self.pid}, specie_id={self.specie_id}, "
+                f"seaport_id={self.seaport_id}, state_id={self.state_id}, "
+                f"size={self.size}, capture_time={self.capture_time})"
+            )
+        ]
+
+        if not self.measures:
+            info.append(f"{pad}  └─ (sem medidas)")
+        else:
+            for idx, measure in enumerate(self.measures, 1):
+                kp_str = " ".join(map(str, measure.kps)) if measure.kps else "[]"
+                info.append(
+                    f"{pad}  ├─ Measure #{idx}: id={measure.measure_id}, "
+                    f"type={measure.type_m}, dist_mm={measure.dist_mm}, "
+                    f"mode={measure.mode.name}, user={measure.user}, "
+                    f"fishid={measure.fishid}, kps=[{kp_str}]"
+                )
+        return "\n".join(info)
+
+    def print(self) -> None:
+        print(self.pretty())
+
+
+# === Pipeline data transfer objects ===
+
+
+def now_iso8601() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class AlignmentRatios:
+    type: str
+    ratioW: float
+    ratioH: float
+
+    def to_dict(self) -> Dict[str, float | str]:
+        return asdict(self)
+
+
+@dataclass
+class CalibrationParameters:
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    alignment: AlignmentRatios
+
+    def to_dict(self) -> Dict[str, float | Dict[str, float | str]]:
+        result = asdict(self)
+        result["alignment"] = self.alignment.to_dict()
+        return result
+
+
+@dataclass
+class ImageInput:
+    image_id: str
+    width: int
+    height: int
+
+
+@dataclass
+class DepthInput:
+    depth_id: str
+    width_depth: int
+    height_depth: int
+    depth_units: str
+
+
+@dataclass
+class PipelineInput:
+    pid: int
+    timestamp_iso: str
+    camera_name: str
+    image: ImageInput
+    depth: DepthInput
+    calibration: CalibrationParameters
+
+
+@dataclass
+class MaskStats:
+    area_px: int
+    bbox: Dict[str, int]
+    touches_border: bool
+    iou_suppressed: bool
+
+
+@dataclass
+class QualityControl:
+    mask_ok: bool
+    depth_valid_fraction: float
+    occlusion_flag: bool
+    method_used: str
+    confidence: float
+
+
+@dataclass
+class LengthMeasurement:
+    px: float
+    mm: float
+    method: str
+    segments_used: int
+
+
+@dataclass
+class PathInfo:
+    type: str
+    num_points: int
+
+
+@dataclass
+class PathSampling:
+    strategy: str
+    pixel_step: float
+
+
+@dataclass
+class MeasurementGeometry:
+    endpoints: Dict[str, Dict[str, Dict[str, float]]]
+    endpoints_3d: Dict[str, Dict[str, Dict[str, float]]]
+    path_info: PathInfo
+    path: Dict[str, List[List[float]] | PathSampling]
+
+
+@dataclass
+class MeasurementError:
+    messages: List[str] = field(default_factory=list)
+
+
+@dataclass
+class MeasurementRecord:
+    center_px: Dict[str, float]
+    prompt_type: str
+    mask_stats: MaskStats
+    qc: QualityControl
+    length: LengthMeasurement
+    geometry: MeasurementGeometry
+    errors: List[str]
+    measure_id: Optional[int] = None
+    fish_id: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        result = asdict(self)
+        result["mask_stats"] = asdict(self.mask_stats)
+        result["qc"] = asdict(self.qc)
+        result["length"] = asdict(self.length)
+        result["geometry"] = {
+            "endpoints": self.geometry.endpoints,
+            "endpoints_3d": self.geometry.endpoints_3d,
+            "path_info": asdict(self.geometry.path_info),
+            "path": {
+                key: asdict(value) if is_dataclass(value) else value
+                for key, value in self.geometry.path.items()
+            },
+        }
+        return result
+
+
+@dataclass
+class ModelsMetadata:
+    density_model: str
+    density_model_version: str
+    sam_model: str
+    sam_model_version: str
+
+
+@dataclass
+class CountsSummary:
+    total_detected: int
+    total_measured: int
+
+
+@dataclass
+class ProcessingMetadata:
+    runtime_ms: int
+    host: str
+    pipeline_version: str
+
+
+@dataclass
+class InferenceOutput:
+    pid: int
+    timestamp_iso: str
+    camera_name: str
+    width: int
+    height: int
+    width_depth: int
+    height_depth: int
+    depth_units: str
+    models: ModelsMetadata
+    calibration: CalibrationParameters
+    counts: CountsSummary
+    measurements: List[MeasurementRecord]
+    processing: ProcessingMetadata
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "pid": self.pid,
+            "timestamp_iso": self.timestamp_iso,
+            "camera_name": self.camera_name,
+            "width": self.width,
+            "height": self.height,
+            "width_depth": self.width_depth,
+            "height_depth": self.height_depth,
+            "depth_units": self.depth_units,
+            "models": asdict(self.models),
+            "calibration": self.calibration.to_dict(),
+            "counts": asdict(self.counts),
+            "measurements": [record.to_dict() for record in self.measurements],
+            "processing": asdict(self.processing),
+        }
+
+
+@dataclass
+class Polygon:
+    points: List[Tuple[float, float]]
+
+    @property
+    def area(self) -> float:
+        return polygon_area(self.points)
+
+
+__all__ = [
+    "MeasureMode",
+    "Measure",
+    "Sample",
+    "AlignmentRatios",
+    "CalibrationParameters",
+    "ImageInput",
+    "DepthInput",
+    "PipelineInput",
+    "MaskStats",
+    "QualityControl",
+    "LengthMeasurement",
+    "MeasurementGeometry",
+    "MeasurementRecord",
+    "ModelsMetadata",
+    "CountsSummary",
+    "ProcessingMetadata",
+    "InferenceOutput",
+    "Polygon",
+]

--- a/src/fish_pipeline/models/density.py
+++ b/src/fish_pipeline/models/density.py
@@ -1,0 +1,94 @@
+"""Density map model definitions without external dependencies."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+Matrix = List[List[float]]
+TrainingSample = Tuple[Matrix, Matrix]
+
+
+def _mean_filter(matrix: Matrix, kernel_size: int = 3) -> Matrix:
+    if not matrix:
+        return []
+    height = len(matrix)
+    width = len(matrix[0])
+    radius = kernel_size // 2
+    result = [[0.0 for _ in range(width)] for _ in range(height)]
+    for y in range(height):
+        for x in range(width):
+            values = []
+            for ky in range(-radius, radius + 1):
+                for kx in range(-radius, radius + 1):
+                    ny = min(max(y + ky, 0), height - 1)
+                    nx = min(max(x + kx, 0), width - 1)
+                    values.append(matrix[ny][nx])
+            result[y][x] = sum(values) / len(values)
+    return result
+
+
+def _normalize(matrix: Matrix) -> Matrix:
+    if not matrix:
+        return []
+    flat = [value for row in matrix for value in row]
+    min_val = min(flat)
+    max_val = max(flat)
+    if max_val == min_val:
+        return [[0.0 for _ in row] for row in matrix]
+    return [[(value - min_val) / (max_val - min_val) for value in row] for row in matrix]
+
+
+def _matrix_sum(matrix: Matrix) -> float:
+    return sum(sum(row) for row in matrix)
+
+
+class BaseDensityModel(ABC):
+    name: str = "BaseDensityModel"
+    version: str = "0.0.1"
+
+    @abstractmethod
+    def train(self, dataset: Iterable[TrainingSample]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def predict(self, image: Matrix) -> Matrix:
+        raise NotImplementedError
+
+
+@dataclass
+class LFCNetLikeDensityModel(BaseDensityModel):
+    kernel_size: int = 3
+
+    def __post_init__(self) -> None:
+        self.name = "LFCNet"
+        self.version = "1.2.0"
+        self._scale = 1.0
+
+    def train(self, dataset: Iterable[TrainingSample]) -> None:
+        total_target = 0.0
+        total_prediction = 0.0
+        count = 0
+        for image, target in dataset:
+            prediction = self._feature_map(image)
+            total_target += _matrix_sum(target)
+            total_prediction += _matrix_sum(prediction)
+            count += 1
+        if count == 0:
+            raise ValueError("Dataset cannot be empty")
+        if total_prediction > 0:
+            self._scale = total_target / total_prediction
+        else:
+            self._scale = 1.0
+
+    def _feature_map(self, image: Matrix) -> Matrix:
+        smoothed = _mean_filter(image, kernel_size=self.kernel_size)
+        return _normalize(smoothed)
+
+    def predict(self, image: Matrix) -> Matrix:
+        feature = self._feature_map(image)
+        return [[value * self._scale for value in row] for row in feature]
+
+    def metadata(self) -> Tuple[str, str]:
+        return self.name, self.version

--- a/src/fish_pipeline/pipelines/__init__.py
+++ b/src/fish_pipeline/pipelines/__init__.py
@@ -1,0 +1,10 @@
+"""Pipeline modules for fish_pipeline."""
+
+from .inference import EndToEndMeasurementPipeline, SkeletonMeasurementPipeline
+from .training import DensityModelTrainingPipeline
+
+__all__ = [
+    "EndToEndMeasurementPipeline",
+    "SkeletonMeasurementPipeline",
+    "DensityModelTrainingPipeline",
+]

--- a/src/fish_pipeline/pipelines/base.py
+++ b/src/fish_pipeline/pipelines/base.py
@@ -1,0 +1,14 @@
+"""Base pipeline abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Pipeline(ABC):
+    """Simple abstraction used by the training and inference pipelines."""
+
+    @abstractmethod
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError

--- a/src/fish_pipeline/pipelines/inference.py
+++ b/src/fish_pipeline/pipelines/inference.py
@@ -1,0 +1,265 @@
+"""Inference pipelines for fish length measurement."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ..data.entities import (
+    CountsSummary,
+    InferenceOutput,
+    LengthMeasurement,
+    MeasurementGeometry,
+    MeasurementRecord,
+    ModelsMetadata,
+    PathInfo,
+    PathSampling,
+    PipelineInput,
+    ProcessingMetadata,
+)
+from ..models.density import BaseDensityModel, LFCNetLikeDensityModel
+from ..steps.density import DensityMapGenerator
+from ..steps.measurement import (
+    EndToEndMeasurementStrategy,
+    LengthMeasurementStrategy,
+    MeasurementComputation,
+    SkeletonMeasurementStrategy,
+)
+from ..steps.peaks import PeakDetector
+from ..steps.preprocessing import Preprocessor, PreprocessingConfig
+from ..steps.qc import QualityController
+from ..steps.segmentation import MaskInstance, PromptedSegmenter
+from ..utils.calibration import DepthProjector
+from .base import Pipeline
+
+
+@dataclass
+class InferenceConfig:
+    preproc: PreprocessingConfig = field(default_factory=PreprocessingConfig)
+    host: str = "worker-01"
+    pipeline_version: str = "rgbd-0.9.3"
+    min_area: int = 150
+    sampling_step_px: float = 4.0
+
+
+@dataclass
+class InferenceRequest:
+    image: List[List[float]]
+    depth_map: List[List[float]]
+    meta: PipelineInput
+
+
+class BaseInferencePipeline(Pipeline):
+    def __init__(
+        self,
+        density_model: Optional[BaseDensityModel] = None,
+        measurement_strategy: Optional[LengthMeasurementStrategy] = None,
+        fallback_strategy: Optional[LengthMeasurementStrategy] = None,
+        config: Optional[InferenceConfig] = None,
+    ) -> None:
+        self.density_model = density_model or LFCNetLikeDensityModel()
+        self.segmenter = PromptedSegmenter()
+        self.peak_detector = PeakDetector()
+        self.measurement_strategy = measurement_strategy or EndToEndMeasurementStrategy()
+        self.fallback_strategy = fallback_strategy
+        self.config = config or InferenceConfig()
+        self.preprocessor = Preprocessor(self.config.preproc)
+        self.qc = QualityController(min_area=self.config.min_area)
+        self.density_step = DensityMapGenerator(self.density_model)
+
+    def run(self, request: InferenceRequest) -> InferenceOutput:
+        start_time = time.time()
+        image_proc, depth_proc = self.preprocessor.run(request.image, request.depth_map)
+        density_result = self.density_step.run(image_proc)
+        peaks = self.peak_detector.run(density_result.density_map)
+        masks = self.segmenter.run(image_proc, peaks)
+
+        projector = DepthProjector(request.meta.calibration)
+        measurements: List[MeasurementRecord] = []
+
+        for instance in masks:
+            measurement = self._measure_instance(
+                instance=instance,
+                depth_map=depth_proc,
+                depth_units=request.meta.depth.depth_units,
+                projector=projector,
+            )
+            if measurement:
+                measurements.append(measurement)
+
+        models_metadata = ModelsMetadata(
+            density_model=self.density_model.name,
+            density_model_version=self.density_model.version,
+            sam_model=self.segmenter.model_name,
+            sam_model_version=self.segmenter.model_version,
+        )
+
+        counts = CountsSummary(
+            total_detected=len(masks),
+            total_measured=len(measurements),
+        )
+
+        runtime_ms = int((time.time() - start_time) * 1000)
+
+        processing = ProcessingMetadata(
+            runtime_ms=runtime_ms,
+            host=self.config.host,
+            pipeline_version=self.config.pipeline_version,
+        )
+
+        meta = request.meta
+        output = InferenceOutput(
+            pid=meta.pid,
+            timestamp_iso=meta.timestamp_iso,
+            camera_name=meta.camera_name,
+            width=meta.image.width,
+            height=meta.image.height,
+            width_depth=meta.depth.width_depth,
+            height_depth=meta.depth.height_depth,
+            depth_units=meta.depth.depth_units,
+            models=models_metadata,
+            calibration=meta.calibration,
+            counts=counts,
+            measurements=measurements,
+            processing=processing,
+        )
+        return output
+
+    def _measure_instance(
+        self,
+        instance: MaskInstance,
+        depth_map: List[List[float]],
+        depth_units: str,
+        projector: DepthProjector,
+    ) -> Optional[MeasurementRecord]:
+        strategies = [self.measurement_strategy]
+        if self.fallback_strategy:
+            strategies.append(self.fallback_strategy)
+
+        for strategy in strategies:
+            try:
+                computation = strategy.measure(
+                    mask=instance.mask,
+                    head_point=(instance.center[0], instance.center[1]),
+                    depth_map=depth_map,
+                    depth_units=depth_units,
+                    projector=projector,
+                )
+                return self._build_measurement_record(instance, computation)
+            except ValueError:
+                continue
+        return None
+
+    def _build_measurement_record(
+        self,
+        instance: MaskInstance,
+        computation: MeasurementComputation,
+    ) -> MeasurementRecord:
+        path_points = [[float(x), float(y)] for x, y in computation.path_rgb]
+        path_type = "segment" if len(path_points) == 2 else "polyline"
+        sampling = PathSampling(strategy="arc_length", pixel_step=self.config.sampling_step_px)
+
+        endpoints = {
+            "rgb_px": {
+                "head": {"x": computation.head[0], "y": computation.head[1]},
+                "tail": {"x": computation.tail[0], "y": computation.tail[1]},
+            }
+        }
+
+        endpoints_3d = self._extract_3d_endpoints(computation.depth_points)
+
+        depth_valid_fraction = computation.depth_valid_fraction
+        raw_confidence = (instance.score + depth_valid_fraction) / 2.0
+        confidence = max(0.0, min(raw_confidence, 1.0))
+
+        qc_eval = self.qc.evaluate(
+            mask=instance.mask,
+            prompt_type=instance.prompt_type,
+            depth_valid_fraction=depth_valid_fraction,
+            method_used=computation.method,
+            confidence=confidence,
+        )
+
+        geometry = MeasurementGeometry(
+            endpoints=endpoints,
+            endpoints_3d=endpoints_3d,
+            path_info=PathInfo(type=path_type, num_points=len(path_points)),
+            path={
+                "rgb_px": path_points,
+                "sampling": sampling,
+            },
+        )
+
+        length_info = LengthMeasurement(
+            px=computation.length_px,
+            mm=computation.length_mm,
+            method=computation.method,
+            segments_used=computation.segments_used,
+        )
+        record = MeasurementRecord(
+            center_px={"x": float(instance.center[0]), "y": float(instance.center[1])},
+            prompt_type=instance.prompt_type,
+            mask_stats=qc_eval.mask_stats,
+            qc=qc_eval.qc,
+            length=length_info,
+            geometry=geometry,
+            errors=qc_eval.errors,
+        )
+        return record
+
+    def _extract_3d_endpoints(
+        self, depth_points: List[Tuple[float, float, float]]
+    ) -> dict[str, dict[str, dict[str, float]]]:
+        result: dict[str, dict[str, dict[str, float]]] = {}
+        valid_indices = [idx for idx, point in enumerate(depth_points) if not self._has_nan(point)]
+        if not valid_indices:
+            return result
+
+        first_idx = valid_indices[0]
+        last_idx = valid_indices[-1]
+        head_point = depth_points[first_idx]
+        tail_point = depth_points[last_idx]
+
+        if first_idx == 0 and last_idx == len(depth_points) - 1 and first_idx != last_idx:
+            result["head_tail_mm"] = {
+                "head": self._point_to_dict(head_point),
+                "tail": self._point_to_dict(tail_point),
+            }
+        else:
+            if first_idx < len(depth_points) - 1:
+                next_point = depth_points[min(first_idx + 1, len(depth_points) - 1)]
+                result["first_valid_segment_mm"] = {
+                    "head": self._point_to_dict(head_point),
+                    "tail": self._point_to_dict(next_point),
+                }
+            if last_idx > 0:
+                prev_point = depth_points[max(last_idx - 1, 0)]
+                result["last_valid_segment_mm"] = {
+                    "p1": self._point_to_dict(prev_point),
+                    "p2": self._point_to_dict(tail_point),
+                }
+        return result
+
+    def _point_to_dict(self, point: Tuple[float, float, float]) -> dict[str, float]:
+        return {"x": float(point[0]), "y": float(point[1]), "z": float(point[2])}
+
+    def _has_nan(self, point: Tuple[float, float, float]) -> bool:
+        return any(value != value for value in point)
+
+
+class EndToEndMeasurementPipeline(BaseInferencePipeline):
+    def __init__(self, config: Optional[InferenceConfig] = None) -> None:
+        super().__init__(
+            measurement_strategy=EndToEndMeasurementStrategy(),
+            config=config,
+        )
+
+
+class SkeletonMeasurementPipeline(BaseInferencePipeline):
+    def __init__(self, config: Optional[InferenceConfig] = None) -> None:
+        super().__init__(
+            measurement_strategy=SkeletonMeasurementStrategy(),
+            fallback_strategy=EndToEndMeasurementStrategy(),
+            config=config,
+        )

--- a/src/fish_pipeline/pipelines/training.py
+++ b/src/fish_pipeline/pipelines/training.py
@@ -1,0 +1,132 @@
+"""Training pipeline for density models using pure Python data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import exp
+from random import Random
+from typing import List, Sequence, Tuple
+
+from ..models.density import BaseDensityModel, LFCNetLikeDensityModel, TrainingSample
+from .base import Pipeline
+
+Matrix = List[List[float]]
+
+
+def _matrix_sum(matrix: Matrix) -> float:
+    return sum(sum(row) for row in matrix)
+
+
+def _normalize(matrix: Matrix) -> Matrix:
+    flat = [value for row in matrix for value in row]
+    min_val = min(flat)
+    max_val = max(flat)
+    if max_val == min_val:
+        return [[0.0 for _ in row] for row in matrix]
+    return [[(value - min_val) / (max_val - min_val) for value in row] for row in matrix]
+
+
+@dataclass
+class TrainingConfig:
+    num_samples: int = 20
+    image_size: Tuple[int, int] = (64, 64)
+    validation_split: float = 0.2
+    random_seed: int = 42
+
+
+@dataclass
+class TrainingReport:
+    training_samples: int
+    validation_samples: int
+    count_mae: float
+    count_rmse: float
+    scale: float
+
+
+class SyntheticDensityDataset:
+    def __init__(self, config: TrainingConfig) -> None:
+        self.config = config
+        self.rng = Random(config.random_seed)
+
+    def generate(self) -> List[TrainingSample]:
+        samples: List[TrainingSample] = []
+        height, width = self.config.image_size
+        for _ in range(self.config.num_samples):
+            image = self._generate_image(height, width)
+            density = _normalize(image)
+            samples.append((image, density))
+        return samples
+
+    def _generate_image(self, height: int, width: int) -> Matrix:
+        image = [[0.0 for _ in range(width)] for _ in range(height)]
+        num_fish = self.rng.randint(1, 3)
+        centers = []
+        for _ in range(num_fish):
+            cx = self.rng.uniform(5, width - 5)
+            cy = self.rng.uniform(5, height - 5)
+            radius = self.rng.uniform(2.0, 4.0)
+            centers.append((cx, cy, radius))
+        for y in range(height):
+            for x in range(width):
+                value = 0.0
+                for cx, cy, radius in centers:
+                    distance_sq = (x - cx) ** 2 + (y - cy) ** 2
+                    value += exp(-distance_sq / (2 * radius ** 2))
+                image[y][x] = value
+        return _normalize(image)
+
+
+class DensityModelTrainer:
+    def __init__(self, model: BaseDensityModel) -> None:
+        self.model = model
+
+    def train(self, dataset: Sequence[TrainingSample]) -> None:
+        self.model.train(dataset)
+
+
+class DensityModelEvaluator:
+    def __init__(self, model: BaseDensityModel) -> None:
+        self.model = model
+
+    def evaluate(self, dataset: Sequence[TrainingSample]) -> Tuple[float, float]:
+        errors = []
+        squared_errors = []
+        for image, target in dataset:
+            prediction = self.model.predict(image)
+            errors.append(abs(_matrix_sum(prediction) - _matrix_sum(target)))
+            diff = _matrix_sum(prediction) - _matrix_sum(target)
+            squared_errors.append(diff * diff)
+        mae = sum(errors) / len(errors) if errors else 0.0
+        rmse = (sum(squared_errors) / len(squared_errors)) ** 0.5 if squared_errors else 0.0
+        return mae, rmse
+
+
+class DensityModelTrainingPipeline(Pipeline):
+    def __init__(
+        self,
+        model: BaseDensityModel | None = None,
+        config: TrainingConfig | None = None,
+    ) -> None:
+        self.model = model or LFCNetLikeDensityModel()
+        self.config = config or TrainingConfig()
+
+    def run(self) -> TrainingReport:
+        dataset = SyntheticDensityDataset(self.config).generate()
+        split = int(len(dataset) * (1 - self.config.validation_split))
+        train_set = dataset[:split]
+        val_set = dataset[split:] if split < len(dataset) else dataset[-1:]
+
+        trainer = DensityModelTrainer(self.model)
+        trainer.train(train_set)
+
+        evaluator = DensityModelEvaluator(self.model)
+        mae, rmse = evaluator.evaluate(val_set)
+
+        scale = getattr(self.model, "_scale", 1.0)
+        return TrainingReport(
+            training_samples=len(train_set),
+            validation_samples=len(val_set),
+            count_mae=mae,
+            count_rmse=rmse,
+            scale=float(scale),
+        )

--- a/src/fish_pipeline/steps/density.py
+++ b/src/fish_pipeline/steps/density.py
@@ -1,0 +1,22 @@
+"""Density map generation step."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from ..models.density import BaseDensityModel
+
+
+@dataclass
+class DensityMapResult:
+    density_map: List[List[float]]
+
+
+class DensityMapGenerator:
+    def __init__(self, model: BaseDensityModel) -> None:
+        self.model = model
+
+    def run(self, image: List[List[float]]) -> DensityMapResult:
+        density_map = self.model.predict(image)
+        return DensityMapResult(density_map=density_map)

--- a/src/fish_pipeline/steps/measurement.py
+++ b/src/fish_pipeline/steps/measurement.py
@@ -1,0 +1,178 @@
+"""Length measurement strategies implemented in pure Python."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from math import hypot
+from typing import Dict, List, Optional, Tuple
+
+from ..utils.calibration import DepthProjector
+from ..utils.geometry import (
+    contour_from_mask,
+    farthest_point_from_reference,
+    polyline_length,
+    raster_to_points,
+)
+
+Mask = List[List[bool]]
+
+
+@dataclass
+class MeasurementComputation:
+    path_rgb: List[Tuple[float, float]]
+    length_px: float
+    length_mm: float
+    head: Tuple[float, float]
+    tail: Tuple[float, float]
+    method: str
+    depth_points: List[Tuple[float, float, float]]
+    depth_valid_fraction: float
+    segments_used: int
+
+
+class LengthMeasurementStrategy:
+    method_name: str = "base"
+
+    def measure(
+        self,
+        mask: Mask,
+        head_point: Tuple[int, int],
+        depth_map: List[List[float]],
+        depth_units: str,
+        projector: DepthProjector,
+    ) -> MeasurementComputation:
+        raise NotImplementedError
+
+
+class EndToEndMeasurementStrategy(LengthMeasurementStrategy):
+    method_name = "end_to_end"
+
+    def measure(
+        self,
+        mask: Mask,
+        head_point: Tuple[int, int],
+        depth_map: List[List[float]],
+        depth_units: str,
+        projector: DepthProjector,
+    ) -> MeasurementComputation:
+        contour = contour_from_mask(mask)
+        if not contour:
+            raise ValueError("Mask has no contour points")
+        tail_point, _, distance = farthest_point_from_reference(contour, head_point)
+        path = [tuple(map(float, head_point)), tuple(map(float, tail_point))]
+        length_mm, depth_points, valid_fraction, segments_used = projector.polyline_length_mm(
+            path, depth_map, depth_units
+        )
+        return MeasurementComputation(
+            path_rgb=path,
+            length_px=distance,
+            length_mm=length_mm,
+            head=tuple(map(float, head_point)),
+            tail=tuple(map(float, tail_point)),
+            method=self.method_name,
+            depth_points=depth_points,
+            depth_valid_fraction=valid_fraction,
+            segments_used=segments_used,
+        )
+
+
+class SkeletonMeasurementStrategy(LengthMeasurementStrategy):
+    method_name = "skeleton"
+
+    def __init__(self, max_nodes: int = 5000) -> None:
+        self.max_nodes = max_nodes
+
+    def measure(
+        self,
+        mask: Mask,
+        head_point: Tuple[int, int],
+        depth_map: List[List[float]],
+        depth_units: str,
+        projector: DepthProjector,
+    ) -> MeasurementComputation:
+        head = self._closest_point_on_mask(mask, head_point)
+        path_pixels = self._longest_path(mask, head)
+        if len(path_pixels) < 2:
+            raise ValueError("Unable to compute skeleton path")
+        path_float = [(float(x), float(y)) for x, y in path_pixels]
+        length_px = polyline_length(path_float)
+        length_mm, depth_points, valid_fraction, segments_used = projector.polyline_length_mm(
+            path_float, depth_map, depth_units
+        )
+        return MeasurementComputation(
+            path_rgb=path_float,
+            length_px=length_px,
+            length_mm=length_mm,
+            head=(float(head[0]), float(head[1])),
+            tail=(float(path_pixels[-1][0]), float(path_pixels[-1][1])),
+            method=self.method_name,
+            depth_points=depth_points,
+            depth_valid_fraction=valid_fraction,
+            segments_used=segments_used,
+        )
+
+    def _closest_point_on_mask(self, mask: Mask, point: Tuple[int, int]) -> Tuple[int, int]:
+        if self._is_inside(mask, point):
+            return point
+        points = raster_to_points(mask)
+        if not points:
+            raise ValueError("Empty mask")
+        best_point = points[0]
+        best_dist = hypot(points[0][0] - point[0], points[0][1] - point[1])
+        for candidate in points[1:]:
+            dist = hypot(candidate[0] - point[0], candidate[1] - point[1])
+            if dist < best_dist:
+                best_dist = dist
+                best_point = candidate
+        return best_point
+
+    def _is_inside(self, mask: Mask, point: Tuple[int, int]) -> bool:
+        x, y = point
+        height = len(mask)
+        width = len(mask[0]) if height else 0
+        if x < 0 or y < 0 or y >= height or x >= width:
+            return False
+        return mask[y][x]
+
+    def _longest_path(self, mask: Mask, head: Tuple[int, int]) -> List[Tuple[int, int]]:
+        height = len(mask)
+        width = len(mask[0]) if height else 0
+        visited = [[False for _ in range(width)] for _ in range(height)]
+        parent: Dict[Tuple[int, int], Optional[Tuple[int, int]]] = {}
+        distance = [[-1 for _ in range(width)] for _ in range(height)]
+
+        queue: deque[Tuple[int, int]] = deque()
+        queue.append(head)
+        visited[head[1]][head[0]] = True
+        distance[head[1]][head[0]] = 0
+        parent[head] = None
+        farthest = head
+
+        while queue and len(parent) < self.max_nodes:
+            cx, cy = queue.popleft()
+            for nx, ny in self._neighbours(cx, cy, width, height):
+                if not mask[ny][nx] or visited[ny][nx]:
+                    continue
+                visited[ny][nx] = True
+                parent[(nx, ny)] = (cx, cy)
+                distance[ny][nx] = distance[cy][cx] + 1
+                queue.append((nx, ny))
+                if distance[ny][nx] > distance[farthest[1]][farthest[0]]:
+                    farthest = (nx, ny)
+
+        path: List[Tuple[int, int]] = []
+        current: Optional[Tuple[int, int]] = farthest
+        while current is not None:
+            path.append(current)
+            current = parent.get(current)
+        return list(reversed(path))
+
+    def _neighbours(self, x: int, y: int, width: int, height: int) -> List[Tuple[int, int]]:
+        candidates = [
+            (x - 1, y),
+            (x + 1, y),
+            (x, y - 1),
+            (x, y + 1),
+        ]
+        return [c for c in candidates if 0 <= c[0] < width and 0 <= c[1] < height]

--- a/src/fish_pipeline/steps/peaks.py
+++ b/src/fish_pipeline/steps/peaks.py
@@ -1,0 +1,68 @@
+"""Peak detection for density maps without external dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+Matrix = List[List[float]]
+
+
+def _mean_filter(matrix: Matrix, radius: int) -> Matrix:
+    if not matrix:
+        return []
+    height = len(matrix)
+    width = len(matrix[0])
+    result = [[0.0 for _ in range(width)] for _ in range(height)]
+    for y in range(height):
+        for x in range(width):
+            values = []
+            for ky in range(-radius, radius + 1):
+                for kx in range(-radius, radius + 1):
+                    ny = min(max(y + ky, 0), height - 1)
+                    nx = min(max(x + kx, 0), width - 1)
+                    values.append(matrix[ny][nx])
+            result[y][x] = sum(values) / len(values)
+    return result
+
+
+def _neighbourhood(matrix: Matrix, x: int, y: int, radius: int) -> Sequence[float]:
+    height = len(matrix)
+    width = len(matrix[0]) if height else 0
+    values = []
+    for ky in range(-radius, radius + 1):
+        for kx in range(-radius, radius + 1):
+            ny = min(max(y + ky, 0), height - 1)
+            nx = min(max(x + kx, 0), width - 1)
+            values.append(matrix[ny][nx])
+    return values
+
+
+@dataclass
+class Peak:
+    x: int
+    y: int
+    value: float
+
+
+class PeakDetector:
+    def __init__(self, radius: int = 2, threshold: float = 0.1) -> None:
+        self.radius = radius
+        self.threshold = threshold
+
+    def run(self, density_map: Matrix) -> List[Peak]:
+        smoothed = _mean_filter(density_map, radius=self.radius)
+        height = len(smoothed)
+        width = len(smoothed[0]) if height else 0
+        peaks: List[Peak] = []
+        for y in range(height):
+            for x in range(width):
+                value = smoothed[y][x]
+                if value <= self.threshold:
+                    continue
+                neighbours = _neighbourhood(smoothed, x, y, self.radius)
+                if value >= max(neighbours):
+                    peaks.append(Peak(x=x, y=y, value=value))
+        peaks.sort(key=lambda peak: peak.value, reverse=True)
+        return peaks

--- a/src/fish_pipeline/steps/preprocessing.py
+++ b/src/fish_pipeline/steps/preprocessing.py
@@ -1,0 +1,97 @@
+"""Image pre-processing implemented without external dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+
+Matrix = List[List[float]]
+
+
+def _ensure_grayscale(image: List[List[float]] | List[List[List[float]]]) -> Matrix:
+    if not image:
+        return []
+    first_row = image[0]
+    if first_row and isinstance(first_row[0], list):
+        # Convert RGB to grayscale via average
+        grayscale: Matrix = []
+        for row in image:  # type: ignore[arg-type]
+            grayscale.append([sum(pixel) / len(pixel) for pixel in row])
+        return grayscale
+    return [list(row) for row in image]  # type: ignore[arg-type]
+
+
+def _mean_filter(matrix: Matrix, kernel_size: int = 3) -> Matrix:
+    if not matrix:
+        return []
+    height = len(matrix)
+    width = len(matrix[0])
+    radius = kernel_size // 2
+    result = [[0.0 for _ in range(width)] for _ in range(height)]
+    for y in range(height):
+        for x in range(width):
+            values = []
+            for ky in range(-radius, radius + 1):
+                for kx in range(-radius, radius + 1):
+                    ny = min(max(y + ky, 0), height - 1)
+                    nx = min(max(x + kx, 0), width - 1)
+                    values.append(matrix[ny][nx])
+            result[y][x] = sum(values) / len(values)
+    return result
+
+
+def _normalize(matrix: Matrix) -> Matrix:
+    if not matrix:
+        return []
+    flat = [value for row in matrix for value in row]
+    min_val = min(flat)
+    max_val = max(flat)
+    if max_val == min_val:
+        return [[0.0 for _ in row] for row in matrix]
+    return [[(value - min_val) / (max_val - min_val) for value in row] for row in matrix]
+
+
+def _resize(matrix: Matrix, target_size: Tuple[int, int]) -> Matrix:
+    if not matrix:
+        return []
+    target_h, target_w = target_size
+    height = len(matrix)
+    width = len(matrix[0])
+    result = [[0.0 for _ in range(target_w)] for _ in range(target_h)]
+    for y in range(target_h):
+        src_y = int(round((y / max(target_h - 1, 1)) * (height - 1))) if target_h > 1 else 0
+        for x in range(target_w):
+            src_x = int(round((x / max(target_w - 1, 1)) * (width - 1))) if target_w > 1 else 0
+            result[y][x] = matrix[src_y][src_x]
+    return result
+
+
+@dataclass
+class PreprocessingConfig:
+    target_size: Optional[Tuple[int, int]] = None
+    kernel_size: int = 3
+    normalize: bool = True
+
+
+class Preprocessor:
+    def __init__(self, config: PreprocessingConfig) -> None:
+        self.config = config
+
+    def run(
+        self,
+        image: List[List[float]] | List[List[List[float]]],
+        depth: Matrix,
+    ) -> Tuple[Matrix, Matrix]:
+        grayscale = _ensure_grayscale(image)
+        smoothed = _mean_filter(grayscale, kernel_size=self.config.kernel_size)
+        if self.config.normalize:
+            smoothed = _normalize(smoothed)
+
+        depth_smoothed = _mean_filter(depth, kernel_size=self.config.kernel_size)
+
+        if self.config.target_size:
+            smoothed = _resize(smoothed, self.config.target_size)
+            depth_smoothed = _resize(depth_smoothed, self.config.target_size)
+
+        return smoothed, depth_smoothed

--- a/src/fish_pipeline/steps/qc.py
+++ b/src/fish_pipeline/steps/qc.py
@@ -1,0 +1,75 @@
+"""Quality control for segmentation masks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from ..data.entities import MaskStats, QualityControl
+from ..utils.geometry import bounding_box_from_mask
+
+
+@dataclass
+class QCEvaluation:
+    mask_stats: MaskStats
+    qc: QualityControl
+    errors: List[str]
+
+
+class QualityController:
+    def __init__(self, min_area: int = 100, border_margin: int = 1) -> None:
+        self.min_area = min_area
+        self.border_margin = border_margin
+
+    def evaluate(
+        self,
+        mask: List[List[bool]],
+        prompt_type: str,
+        depth_valid_fraction: float,
+        method_used: str,
+        confidence: float,
+    ) -> QCEvaluation:
+        area = sum(1 for row in mask for value in row if value)
+        x, y, w, h = bounding_box_from_mask(mask)
+        touches_border = self._touches_border(mask)
+        mask_ok = area >= self.min_area and not touches_border
+        occlusion_flag = depth_valid_fraction < 0.7
+
+        mask_stats = MaskStats(
+            area_px=area,
+            bbox={"x": x, "y": y, "w": w, "h": h},
+            touches_border=touches_border,
+            iou_suppressed=False,
+        )
+
+        qc = QualityControl(
+            mask_ok=mask_ok,
+            depth_valid_fraction=float(depth_valid_fraction),
+            occlusion_flag=occlusion_flag,
+            method_used=method_used,
+            confidence=float(confidence),
+        )
+
+        errors: List[str] = []
+        if not mask_ok:
+            errors.append("mask_failed_qc")
+        if occlusion_flag:
+            errors.append("occlusion_suspected")
+        if depth_valid_fraction == 0:
+            errors.append("no_valid_depth")
+
+        return QCEvaluation(mask_stats=mask_stats, qc=qc, errors=errors)
+
+    def _touches_border(self, mask: List[List[bool]]) -> bool:
+        if not mask:
+            return False
+        height = len(mask)
+        width = len(mask[0])
+        if any(mask[0]):
+            return True
+        if any(mask[-1]):
+            return True
+        for row in mask:
+            if row[0] or row[-1]:
+                return True
+        return False

--- a/src/fish_pipeline/steps/segmentation.py
+++ b/src/fish_pipeline/steps/segmentation.py
@@ -1,0 +1,64 @@
+"""Instance segmentation via promptable model (pure Python)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+from .peaks import Peak
+
+Mask = List[List[bool]]
+
+
+def _create_empty_mask(height: int, width: int) -> Mask:
+    return [[False for _ in range(width)] for _ in range(height)]
+
+
+def _circle_mask(center_x: int, center_y: int, radius: int, height: int, width: int) -> Mask:
+    mask = _create_empty_mask(height, width)
+    radius_sq = radius * radius
+    for y in range(max(center_y - radius, 0), min(center_y + radius + 1, height)):
+        for x in range(max(center_x - radius, 0), min(center_x + radius + 1, width)):
+            if (x - center_x) ** 2 + (y - center_y) ** 2 <= radius_sq:
+                mask[y][x] = True
+    return mask
+
+
+def _mask_score(mask: Mask) -> float:
+    total = sum(1 for row in mask for value in row if value)
+    return min(max(total / 400.0, 0.5), 1.0)
+
+
+@dataclass
+class MaskInstance:
+    mask: Mask
+    center: Tuple[int, int]
+    prompt_type: str
+    score: float
+
+
+class PromptedSegmenter:
+    def __init__(self, radius: int = 8, model_name: str = "SAM-HQ", model_version: str = "0.4.1") -> None:
+        self.radius = radius
+        self.model_name = model_name
+        self.model_version = model_version
+
+    def run(self, image: List[List[float]], peaks: Iterable[Peak]) -> List[MaskInstance]:
+        height = len(image)
+        width = len(image[0]) if height else 0
+        instances: List[MaskInstance] = []
+        for peak in peaks:
+            mask = _circle_mask(peak.x, peak.y, self.radius, height, width)
+            score = _mask_score(mask)
+            instances.append(
+                MaskInstance(
+                    mask=mask,
+                    center=(peak.x, peak.y),
+                    prompt_type="point",
+                    score=score,
+                )
+            )
+        return instances
+
+    def metadata(self) -> Tuple[str, str]:
+        return self.model_name, self.model_version

--- a/src/fish_pipeline/utils/calibration.py
+++ b/src/fish_pipeline/utils/calibration.py
@@ -1,0 +1,79 @@
+"""Calibration helpers implemented using the standard library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import sqrt
+from typing import List, Sequence, Tuple
+
+from ..data.entities import CalibrationParameters
+
+
+DEPTH_UNIT_TO_MM = {
+    "mm": 1.0,
+    "m": 1000.0,
+    "cm": 10.0,
+}
+
+
+@dataclass
+class DepthProjector:
+    calibration: CalibrationParameters
+
+    def depth_scale(self, depth_units: str) -> float:
+        return DEPTH_UNIT_TO_MM.get(depth_units.lower(), 1.0)
+
+    def rgb_to_depth_coordinates(self, x: float, y: float) -> Tuple[float, float]:
+        ratios = self.calibration.alignment
+        if ratios.type != "ratios":
+            return x, y
+        return x / ratios.ratioW, y / ratios.ratioH
+
+    def pixel_to_camera(self, x: float, y: float, depth_value: float, depth_units: str) -> Tuple[float, float, float]:
+        scale = self.depth_scale(depth_units)
+        z = depth_value * scale
+        fx = self.calibration.fx
+        fy = self.calibration.fy
+        cx = self.calibration.cx
+        cy = self.calibration.cy
+        X = (x - cx) * z / fx
+        Y = (y - cy) * z / fy
+        return float(X), float(Y), float(z)
+
+    def polyline_length_mm(
+        self,
+        polyline: Sequence[Tuple[float, float]],
+        depth_map: List[List[float]],
+        depth_units: str,
+    ) -> Tuple[float, List[Tuple[float, float, float]], float, int]:
+        if len(polyline) < 2:
+            return 0.0, [], 0.0, 0
+
+        projected_points: List[Tuple[float, float, float]] = []
+        valid_segments = 0
+        total_length = 0.0
+
+        height = len(depth_map)
+        width = len(depth_map[0]) if height else 0
+
+        for x, y in polyline:
+            depth_x, depth_y = self.rgb_to_depth_coordinates(x, y)
+            depth_x = max(0, min(width - 1, int(round(depth_x))))
+            depth_y = max(0, min(height - 1, int(round(depth_y))))
+            depth_value = depth_map[depth_y][depth_x]
+            if depth_value <= 0:
+                projected_points.append((float("nan"), float("nan"), float("nan")))
+            else:
+                projected_points.append(self.pixel_to_camera(x, y, depth_value, depth_units))
+
+        for idx in range(1, len(projected_points)):
+            p1 = projected_points[idx - 1]
+            p2 = projected_points[idx]
+            if any(value != value for value in p1) or any(value != value for value in p2):  # check for NaN
+                continue
+            distance = sqrt((p1[0] - p2[0]) ** 2 + (p1[1] - p2[1]) ** 2 + (p1[2] - p2[2]) ** 2)
+            total_length += distance
+            valid_segments += 1
+
+        valid_fraction = valid_segments / max(len(polyline) - 1, 1)
+        return total_length, projected_points, valid_fraction, valid_segments

--- a/src/fish_pipeline/utils/geometry.py
+++ b/src/fish_pipeline/utils/geometry.py
@@ -1,0 +1,151 @@
+"""Geometry helper functions implemented with standard Python."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import hypot
+from typing import Iterable, List, Sequence, Tuple
+
+
+@dataclass
+class OrientedBBox:
+    centroid: Tuple[float, float]
+    size: Tuple[float, float]
+    angle: float
+
+
+def oriented_bbox_with_ratio(
+    points: Sequence[Tuple[float, float]], ratio: float = 3.0
+) -> Tuple[OrientedBBox, List[Tuple[float, float]]]:
+    if len(points) < 1:
+        raise ValueError("At least one point required")
+
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    x_min, x_max = min(xs), max(xs)
+    y_min, y_max = min(ys), max(ys)
+    width = max(x_max - x_min, 1.0)
+    height = max(y_max - y_min, 1.0)
+
+    current_ratio = max(width, height) / max(min(width, height), 1.0)
+    if current_ratio < ratio:
+        if width > height:
+            height = width / ratio
+        else:
+            width = height / ratio
+
+    centroid = ((x_min + x_max) / 2.0, (y_min + y_max) / 2.0)
+    corners = [
+        (x_min, y_min),
+        (x_max, y_min),
+        (x_max, y_max),
+        (x_min, y_max),
+    ]
+    return OrientedBBox(centroid=centroid, size=(width, height), angle=0.0), corners
+
+
+def ensure_clockwise_quadrilateral(
+    x_min: float, y_min: float, x_max: float, y_max: float
+) -> List[Tuple[float, float]]:
+    return [
+        (x_min, y_min),
+        (x_max, y_min),
+        (x_max, y_max),
+        (x_min, y_max),
+    ]
+
+
+def polygon_area(points: Sequence[Tuple[float, float]]) -> float:
+    if len(points) < 3:
+        return 0.0
+    area = 0.0
+    for idx in range(len(points)):
+        x1, y1 = points[idx]
+        x2, y2 = points[(idx + 1) % len(points)]
+        area += x1 * y2 - y1 * x2
+    return 0.5 * area
+
+
+def bounding_box_from_mask(mask: Sequence[Sequence[bool]]) -> Tuple[int, int, int, int]:
+    ys = []
+    xs = []
+    for y, row in enumerate(mask):
+        for x, value in enumerate(row):
+            if value:
+                xs.append(x)
+                ys.append(y)
+    if not xs:
+        return 0, 0, 0, 0
+    x_min = min(xs)
+    x_max = max(xs)
+    y_min = min(ys)
+    y_max = max(ys)
+    return x_min, y_min, x_max - x_min + 1, y_max - y_min + 1
+
+
+def contour_from_mask(mask: Sequence[Sequence[bool]]) -> List[Tuple[int, int]]:
+    points: List[Tuple[int, int]] = []
+    height = len(mask)
+    width = len(mask[0]) if height else 0
+    for y in range(height):
+        for x in range(width):
+            if not mask[y][x]:
+                continue
+            neighbours = [
+                (x - 1, y),
+                (x + 1, y),
+                (x, y - 1),
+                (x, y + 1),
+            ]
+            if any(
+                nx < 0
+                or ny < 0
+                or nx >= width
+                or ny >= height
+                or not mask[ny][nx]
+                for nx, ny in neighbours
+            ):
+                points.append((x, y))
+    return points
+
+
+def farthest_point_from_reference(
+    points: Iterable[Tuple[int, int]], reference: Tuple[int, int]
+) -> Tuple[Tuple[int, int], float, float]:
+    ref_x, ref_y = reference
+    max_dist = -1.0
+    farthest = reference
+    for x, y in points:
+        dist = hypot(x - ref_x, y - ref_y)
+        if dist > max_dist:
+            max_dist = dist
+            farthest = (x, y)
+    return farthest, max_dist, max_dist
+
+
+def polyline_length(points: Sequence[Tuple[float, float]]) -> float:
+    length = 0.0
+    for idx in range(1, len(points)):
+        x1, y1 = points[idx - 1]
+        x2, y2 = points[idx]
+        length += hypot(x2 - x1, y2 - y1)
+    return length
+
+
+def decimate_polyline(points: Sequence[Tuple[float, float]], step: int) -> List[Tuple[float, float]]:
+    if len(points) <= 2 or step <= 1:
+        return list(points)
+    decimated = [points[0]]
+    for idx in range(1, len(points) - 1, step):
+        decimated.append(points[idx])
+    decimated.append(points[-1])
+    return decimated
+
+
+def raster_to_points(mask: Sequence[Sequence[bool]]) -> List[Tuple[int, int]]:
+    points: List[Tuple[int, int]] = []
+    for y, row in enumerate(mask):
+        for x, value in enumerate(row):
+            if value:
+                points.append((x, y))
+    return points

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone
+from math import exp
+
+from fish_pipeline.data.entities import (
+    AlignmentRatios,
+    CalibrationParameters,
+    DepthInput,
+    ImageInput,
+    PipelineInput,
+)
+from fish_pipeline.pipelines.inference import (
+    EndToEndMeasurementPipeline,
+    InferenceConfig,
+    InferenceRequest,
+    SkeletonMeasurementPipeline,
+)
+
+
+def make_meta(width: int, height: int) -> PipelineInput:
+    calibration = CalibrationParameters(
+        fx=575.2,
+        fy=575.0,
+        cx=width / 2.0,
+        cy=height / 2.0,
+        alignment=AlignmentRatios(type="ratios", ratioW=1.0, ratioH=1.0),
+    )
+    image_meta = ImageInput(image_id="img_1", width=width, height=height)
+    depth_meta = DepthInput(depth_id="depth_1", width_depth=width, height_depth=height, depth_units="mm")
+    return PipelineInput(
+        pid=123,
+        timestamp_iso=datetime.now(timezone.utc).isoformat(),
+        camera_name="realsense_d415",
+        image=image_meta,
+        depth=depth_meta,
+        calibration=calibration,
+    )
+
+
+def make_blob_image(height: int, width: int, centers: list[tuple[int, int]]) -> list[list[float]]:
+    image = [[0.0 for _ in range(width)] for _ in range(height)]
+    for y in range(height):
+        for x in range(width):
+            value = 0.0
+            for cx, cy in centers:
+                distance_sq = (x - cx) ** 2 + (y - cy) ** 2
+                value += exp(-distance_sq / (2 * 25.0))
+            image[y][x] = value
+    return image
+
+
+def make_depth_map(height: int, width: int, value: float = 1000.0) -> list[list[float]]:
+    return [[value for _ in range(width)] for _ in range(height)]
+
+
+def make_test_request(num_fish: int = 2) -> InferenceRequest:
+    height = width = 96
+    centers = [(30, 40), (65, 55)][:num_fish]
+    image = make_blob_image(height, width, centers)
+    depth_map = make_depth_map(height, width)
+    meta = make_meta(width, height)
+    return InferenceRequest(image=image, depth_map=depth_map, meta=meta)
+
+
+def test_end_to_end_pipeline_output_structure():
+    request = make_test_request()
+    pipeline = EndToEndMeasurementPipeline(config=InferenceConfig())
+    output = pipeline.run(request)
+
+    assert output.counts.total_detected >= 2
+    assert output.counts.total_measured == len(output.measurements)
+    assert output.models.density_model == "LFCNet"
+    assert all(measure.length.method == "end_to_end" for measure in output.measurements)
+
+    result_dict = output.to_dict()
+    assert "measurements" in result_dict
+    assert result_dict["measurements"][0]["geometry"]["path"]["sampling"]["strategy"] == "arc_length"
+
+
+def test_skeleton_pipeline_uses_fallback_when_needed():
+    request = make_test_request()
+    pipeline = SkeletonMeasurementPipeline(config=InferenceConfig())
+
+    class FailingStrategy:
+        method_name = "skeleton"
+
+        def measure(self, *args, **kwargs):
+            raise ValueError("failure")
+
+    pipeline.measurement_strategy = FailingStrategy()
+    output = pipeline.run(request)
+    assert all(measure.length.method == "end_to_end" for measure in output.measurements)

--- a/tests/test_measurement_strategies.py
+++ b/tests/test_measurement_strategies.py
@@ -1,0 +1,52 @@
+from fish_pipeline.data.entities import AlignmentRatios, CalibrationParameters
+from fish_pipeline.steps.measurement import (
+    EndToEndMeasurementStrategy,
+    SkeletonMeasurementStrategy,
+)
+from fish_pipeline.utils.calibration import DepthProjector
+
+
+def build_projector(width: int, height: int) -> DepthProjector:
+    calibration = CalibrationParameters(
+        fx=500.0,
+        fy=500.0,
+        cx=width / 2.0,
+        cy=height / 2.0,
+        alignment=AlignmentRatios(type="ratios", ratioW=1.0, ratioH=1.0),
+    )
+    return DepthProjector(calibration)
+
+
+def build_mask(height: int, width: int) -> list[list[bool]]:
+    mask = [[False for _ in range(width)] for _ in range(height)]
+    for y in range(18, 22):
+        for x in range(5, 30):
+            mask[y][x] = True
+    for y in range(22, 32):
+        for x in range(27, 31):
+            mask[y][x] = True
+    return mask
+
+
+def build_depth_map(height: int, width: int, value: float = 1000.0) -> list[list[float]]:
+    return [[value for _ in range(width)] for _ in range(height)]
+
+
+def test_skeleton_longer_than_end_to_end_for_curved_mask():
+    height, width = 40, 40
+    mask = build_mask(height, width)
+    depth_map = build_depth_map(height, width)
+    projector = build_projector(width, height)
+
+    head_point = (7, 20)
+
+    end_to_end = EndToEndMeasurementStrategy()
+    skeleton = SkeletonMeasurementStrategy()
+
+    end_result = end_to_end.measure(mask, head_point, depth_map, "mm", projector)
+    skeleton_result = skeleton.measure(mask, head_point, depth_map, "mm", projector)
+
+    assert skeleton_result.length_px > end_result.length_px
+    assert skeleton_result.method == "skeleton"
+    assert end_result.method == "end_to_end"
+    assert len(skeleton_result.path_rgb) > 2

--- a/tests/test_training_pipeline.py
+++ b/tests/test_training_pipeline.py
@@ -1,0 +1,16 @@
+from fish_pipeline.pipelines.training import (
+    DensityModelTrainingPipeline,
+    TrainingConfig,
+)
+
+
+def test_training_pipeline_runs_and_reports_metrics():
+    config = TrainingConfig(num_samples=10, image_size=(32, 32), validation_split=0.3, random_seed=1)
+    pipeline = DensityModelTrainingPipeline(config=config)
+    report = pipeline.run()
+
+    assert report.training_samples > 0
+    assert report.validation_samples > 0
+    assert report.count_mae >= 0
+    assert report.count_rmse >= 0
+    assert report.scale > 0


### PR DESCRIPTION
## Summary
- implement pure Python inference pipelines with preprocessing, density estimation, segmentation, QC and measurement output formatting
- add reusable measurement strategies for end-to-end and skeleton-based length calculations plus depth-aware projection utilities
- create a synthetic-data training pipeline and document project usage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1603feedc832b9876dd4577064512